### PR TITLE
Add principals with one component to ACL

### DIFF
--- a/hooks/install
+++ b/hooks/install
@@ -35,7 +35,7 @@ EOL
 
 echo "Setting up kerberos ACL configuration at /etc/krb5kdc/kadm5.acl"
 mkdir /etc/krb5kdc
-echo -e "*/*@${KERBEROS_REALM^^}\t*" > /etc/krb5kdc/kadm5.acl
+echo -e "*@${KERBEROS_REALM^^}\t*\n*/*@${KERBEROS_REALM^^}\t*\n" > /etc/krb5kdc/kadm5.acl
 
 echo "Installing all the packages required in this test"
 apt-get update


### PR DESCRIPTION
The `admin` principal is not allowed to run

    list_principals

For example because the current ACL only grants principals with two
component names the `list` privilege. This change adds principals with
a name that consists of one component to the ACL.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>